### PR TITLE
feat: Emit DAO Created events on MultiSig, Governance, and NFT DAO creation.

### DIFF
--- a/contracts/dao/GovernanceDAOFactory.sol
+++ b/contracts/dao/GovernanceDAOFactory.sol
@@ -3,4 +3,34 @@ pragma solidity ^0.8.0;
 
 import "./DAOFactory.sol";
 
-contract GovernanceDAOFactory is DAOFactory {}
+contract GovernanceDAOFactory is DAOFactory {
+    event GovernanceDAOCreated(DAODetails daoDetails);
+
+    function emitGovernanceDAOCreated(
+        DAODetails memory governanceDAODetails
+    ) internal {
+        emit GovernanceDAOCreated(governanceDAODetails);
+    }
+
+    function createDAO(
+        address _admin,
+        string calldata _name,
+        string calldata _logoUrl,
+        IERC20 _tokenAddress,
+        uint256 _quorumThreshold,
+        uint256 _votingDelay,
+        uint256 _votingPeriod,
+        bool _isPrivate
+    ) external returns (address) {
+        return
+            super.createDAO(
+                _admin,
+                _name,
+                _logoUrl,
+                _tokenAddress,
+                VotingRules(_quorumThreshold, _votingDelay, _votingPeriod),
+                _isPrivate,
+                emitGovernanceDAOCreated
+            );
+    }
+}

--- a/contracts/dao/MultisigDAOFactory.sol
+++ b/contracts/dao/MultisigDAOFactory.sol
@@ -14,8 +14,16 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 contract MultisigDAOFactory is OwnableUpgradeable, IEvents, IErrors {
-    event PublicDaoCreated(address daoAddress);
-    event PrivateDaoCreated(address daoAddress);
+    event MultiSigDAOCreated(
+        address daoAddress,
+        address safeAddress,
+        address admin,
+        string name,
+        string logoUrl,
+        address[] owners,
+        uint256 threshold,
+        bool isPrivate
+    );
 
     error NotAdmin(string message);
 
@@ -95,12 +103,19 @@ contract MultisigDAOFactory is OwnableUpgradeable, IEvents, IErrors {
             _logoUrl,
             hederaGnosisSafe
         );
-        if (_isPrivate) {
-            emit PrivateDaoCreated(createdDAOAddress);
-        } else {
+        if (!_isPrivate) {
             daos.push(createdDAOAddress);
-            emit PublicDaoCreated(createdDAOAddress);
         }
+        emit MultiSigDAOCreated(
+            createdDAOAddress,
+            address(hederaGnosisSafe),
+            _admin,
+            _name,
+            _logoUrl,
+            _owners,
+            _threshold,
+            _isPrivate
+        );
         return createdDAOAddress;
     }
 

--- a/contracts/dao/NFTDAOFactory.sol
+++ b/contracts/dao/NFTDAOFactory.sol
@@ -3,4 +3,32 @@ pragma solidity ^0.8.0;
 
 import "./DAOFactory.sol";
 
-contract NFTDAOFactory is DAOFactory {}
+contract NFTDAOFactory is DAOFactory {
+    event NFTDAOCreated(DAODetails daoDetails);
+
+    function emitNFTDAOCreated(DAODetails memory nftDAODetails) internal {
+        emit NFTDAOCreated(nftDAODetails);
+    }
+
+    function createDAO(
+        address _admin,
+        string calldata _name,
+        string calldata _logoUrl,
+        IERC20 _tokenAddress,
+        uint256 _quorumThreshold,
+        uint256 _votingDelay,
+        uint256 _votingPeriod,
+        bool _isPrivate
+    ) external returns (address) {
+        return
+            super.createDAO(
+                _admin,
+                _name,
+                _logoUrl,
+                _tokenAddress,
+                VotingRules(_quorumThreshold, _votingDelay, _votingPeriod),
+                _isPrivate,
+                emitNFTDAOCreated
+            );
+    }
+}

--- a/test/governor-dao-factory-test.ts
+++ b/test/governor-dao-factory-test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { BigNumber } from "ethers";
 import { TestHelper } from "./TestHelper";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { Events, GovernanceDAOCreatedEventLog } from "./types";
 
 describe("GovernanceDAOFactory contract tests", function () {
   const zeroAddress = "0x0000000000000000000000000000000000000000";
@@ -184,6 +185,46 @@ describe("GovernanceDAOFactory contract tests", function () {
       .withArgs("DAOFactory: voting period is zero");
   });
 
+  it("Verify createDAO should emit GovernanceDAOCreated event when a DAO is created", async function () {
+    const { governorDAOFactoryInstance, daoAdminOne, token } =
+      await loadFixture(deployFixture);
+
+    const txn = await governorDAOFactoryInstance.createDAO(
+      daoAdminOne.address,
+      DAO_NAME,
+      LOGO_URL,
+      token.address,
+      BigNumber.from(500),
+      BigNumber.from(0),
+      BigNumber.from(100),
+      false
+    );
+
+    const { name, args } = await TestHelper.readLastEvent(txn);
+    expect(name).to.be.equal(Events.GovernanceDAOCreated);
+
+    const argsWithNames =
+      TestHelper.getEventArgumentsByName<GovernanceDAOCreatedEventLog>(args);
+    const { daoDetails } = argsWithNames;
+    expect(daoDetails).to.have.property("daoAddress");
+
+    const { daoAddress } = daoDetails;
+    expect(daoAddress).to.have.lengthOf.greaterThan(0);
+
+    expect(daoDetails).to.deep.include({
+      admin: daoAdminOne.address,
+      name: "DAO_NAME",
+      logoUrl: "LOGO_URL",
+      tokenAddress: token.address,
+      votingRules: {
+        quorumThreshold: BigNumber.from(500),
+        votingDelay: BigNumber.from(0),
+        votingPeriod: BigNumber.from(100),
+      },
+      isPrivate: false,
+    });
+  });
+
   it("Verify createDAO should add new dao into list when the dao is public", async function () {
     const { governorDAOFactoryInstance, daoAdminOne, token } =
       await loadFixture(deployFixture);
@@ -202,9 +243,12 @@ describe("GovernanceDAOFactory contract tests", function () {
       false
     );
 
-    const lastEvent = (await txn.wait()).events.pop();
-    expect(lastEvent.event).to.be.equal("PublicDaoCreated");
-    expect(lastEvent.args.daoAddress).not.to.be.equal("0x0");
+    const { args } = await TestHelper.readLastEvent(txn);
+    const argsWithNames =
+      TestHelper.getEventArgumentsByName<GovernanceDAOCreatedEventLog>(args);
+    const { daoAddress, isPrivate } = argsWithNames.daoDetails;
+    expect(isPrivate).to.be.equal(false);
+    expect(daoAddress).not.to.be.equal("0x0");
 
     const updatedList = await governorDAOFactoryInstance.getDAOs();
     expect(updatedList.length).to.be.equal(1);
@@ -228,9 +272,12 @@ describe("GovernanceDAOFactory contract tests", function () {
       true
     );
 
-    const lastEvent = (await txn.wait()).events.pop();
-    expect(lastEvent.event).to.be.equal("PrivateDaoCreated");
-    expect(lastEvent.args.daoAddress).not.to.be.equal("0x0");
+    const { args } = await TestHelper.readLastEvent(txn);
+    const argsWithNames =
+      TestHelper.getEventArgumentsByName<GovernanceDAOCreatedEventLog>(args);
+    const { daoAddress, isPrivate } = argsWithNames.daoDetails;
+    expect(isPrivate).to.be.equal(true);
+    expect(daoAddress).not.to.be.equal("0x0");
 
     const updatedList = await governorDAOFactoryInstance.getDAOs();
     expect(updatedList.length).to.be.equal(0);

--- a/test/governor-dao-test.ts
+++ b/test/governor-dao-test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { BigNumber } from "ethers";
 import { TestHelper } from "./TestHelper";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { Events, GovernanceDAOCreatedEventLog } from "./types";
 
 describe("GovernanceTokenDAO tests", function () {
   const QUORUM_THRESHOLD = 5;
@@ -220,9 +221,12 @@ describe("GovernanceTokenDAO tests", function () {
         false
       );
 
-      const lastEvent = (await txn.wait()).events.pop();
-      expect(lastEvent.event).to.be.equal("PublicDaoCreated");
-      expect(lastEvent.args.daoAddress).not.to.be.equal("0x0");
+      const { args } = await TestHelper.readLastEvent(txn);
+      const argsWithNames =
+        TestHelper.getEventArgumentsByName<GovernanceDAOCreatedEventLog>(args);
+      const { daoAddress, isPrivate } = argsWithNames.daoDetails;
+      expect(isPrivate).to.be.equal(false);
+      expect(daoAddress).not.to.be.equal("0x0");
 
       const updatedList = await governorDAOFactory.getDAOs();
       expect(updatedList.length).to.be.equal(1);
@@ -247,9 +251,12 @@ describe("GovernanceTokenDAO tests", function () {
         true
       );
 
-      const lastEvent = (await txn.wait()).events.pop();
-      expect(lastEvent.event).to.be.equal("PrivateDaoCreated");
-      expect(lastEvent.args.daoAddress).not.to.be.equal("0x0");
+      const { args } = await TestHelper.readLastEvent(txn);
+      const argsWithNames =
+        TestHelper.getEventArgumentsByName<GovernanceDAOCreatedEventLog>(args);
+      const { daoAddress, isPrivate } = argsWithNames.daoDetails;
+      expect(isPrivate).to.be.equal(true);
+      expect(daoAddress).not.to.be.equal("0x0");
 
       const updatedList = await governorDAOFactory.getDAOs();
       expect(updatedList.length).to.be.equal(0);

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,37 @@
+import { BigNumber } from "ethers";
+
+interface DAOCreatedEventLog {
+  daoDetails: {
+    daoAddress: string;
+    admin: string;
+    name: string;
+    logoUrl: string;
+    tokenAddress: string;
+    votingRules: {
+      quorumThreshold: BigNumber;
+      votingDelay: BigNumber;
+      votingPeriod: BigNumber;
+    };
+    isPrivate: boolean;
+  };
+}
+
+export interface GovernanceDAOCreatedEventLog extends DAOCreatedEventLog {}
+export interface NFTDAOCreatedEventLog extends DAOCreatedEventLog {}
+
+export interface MultiSigDAOCreatedEventLog {
+  daoAddress: string;
+  safeAddress: string;
+  admin: string;
+  name: string;
+  logoUrl: string;
+  owners: string[];
+  threshold: BigNumber;
+  isPrivate: boolean;
+}
+
+export enum Events {
+  GovernanceDAOCreated = "GovernanceDAOCreated",
+  MultiSigDAOCreated = "MultiSigDAOCreated",
+  NFTDAOCreated = "NFTDAOCreated",
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Determines whether the given `value` is iterable.
+ * @param value - The value to check.
+ * @returns True if the value is iterable, false otherwise.
+ */
+export function isIterable(value: any): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  return typeof value[Symbol.iterator] === "function";
+}


### PR DESCRIPTION
📝**Overview**
The preferred method of fetching UI data from contracts is through event logs. These changes add events that emit details about Governance and MultiSig DAOs when they are created. This will allow the UI to fetch all DAOs for the DAOs list page using event logs instead of the JSON RPC Service. 

🚀 **Features**
- Added a `GovernanceDAOCreated` Event to the GovernanceDAOFactory. Emitting the event in the `createDAO` function.
- Added a `MultiSigDAOCreated` Event to the MultisigDAOFactory. Emitting the event in the `createDAO` function.
- Added an `NFTDAOCreated` Event to the NFTDAOFactory. Emitting the event in the `createDAO` function.