### PR TITLE
fix: Make Logo URL optional

### DIFF
--- a/contracts/dao/BaseDAO.sol
+++ b/contracts/dao/BaseDAO.sol
@@ -23,9 +23,6 @@ abstract contract BaseDAO is OwnableUpgradeable, IErrors {
         if (bytes(name).length == 0) {
             revert InvalidInput("BaseDAO: name is empty");
         }
-        if (bytes(logoUrl).length == 0) {
-            revert InvalidInput("BaseDAO: url is empty");
-        }
         if (address(admin) == address(0)) {
             revert InvalidInput("BaseDAO: admin address is zero");
         }

--- a/contracts/dao/DAOFactory.sol
+++ b/contracts/dao/DAOFactory.sol
@@ -126,9 +126,6 @@ contract DAOFactory is OwnableUpgradeable, IEvents, IErrors {
         if (bytes(_name).length == 0) {
             revert InvalidInput("DAOFactory: name is empty");
         }
-        if (bytes(_logoUrl).length == 0) {
-            revert InvalidInput("DAOFactory: url is empty");
-        }
         if (address(_tokenAddress) == address(0)) {
             revert InvalidInput("DAOFactory: token address is zero");
         }

--- a/test/governor-dao-factory-test.ts
+++ b/test/governor-dao-factory-test.ts
@@ -126,25 +126,6 @@ describe("GovernanceDAOFactory contract tests", function () {
       .withArgs("DAOFactory: name is empty");
   });
 
-  it("Verify createDAO should be reverted when dao url is empty", async function () {
-    const { governorDAOFactoryInstance, daoAdminOne, token } =
-      await loadFixture(deployFixture);
-    await expect(
-      governorDAOFactoryInstance.createDAO(
-        daoAdminOne.address,
-        DAO_NAME,
-        "",
-        token.address,
-        BigNumber.from(500),
-        BigNumber.from(0),
-        BigNumber.from(100),
-        true
-      )
-    )
-      .to.revertedWithCustomError(governorDAOFactoryInstance, "InvalidInput")
-      .withArgs("DAOFactory: url is empty");
-  });
-
   it("Verify createDAO should be reverted when token address is zero", async function () {
     const { governorDAOFactoryInstance, daoAdminOne } = await loadFixture(
       deployFixture

--- a/test/governor-dao-test.ts
+++ b/test/governor-dao-test.ts
@@ -141,26 +141,6 @@ describe("GovernanceTokenDAO tests", function () {
         .withArgs("DAOFactory: name is empty");
     });
 
-    it("Verify createDAO should be reverted when dao url is empty", async function () {
-      const { governorDAOFactory, daoAdminOne, token } = await loadFixture(
-        deployFixture
-      );
-      await expect(
-        governorDAOFactory.createDAO(
-          daoAdminOne.address,
-          DAO_NAME,
-          "",
-          token.address,
-          BigNumber.from(500),
-          BigNumber.from(0),
-          BigNumber.from(100),
-          true
-        )
-      )
-        .to.revertedWithCustomError(governorDAOFactory, "InvalidInput")
-        .withArgs("DAOFactory: url is empty");
-    });
-
     it("Verify createDAO should be reverted when token address is zero", async function () {
       const { governorDAOFactory, daoAdminOne } = await loadFixture(
         deployFixture
@@ -420,17 +400,6 @@ describe("GovernanceTokenDAO tests", function () {
       )
         .revertedWithCustomError(governorTokenDAO, "InvalidInput")
         .withArgs("BaseDAO: name is empty");
-
-      await expect(
-        governorTokenDAO.initialize(
-          daoAdminOne.address,
-          DAO_NAME,
-          "",
-          governorTT.address
-        )
-      )
-        .revertedWithCustomError(governorTokenDAO, "InvalidInput")
-        .withArgs("BaseDAO: url is empty");
 
       await expect(
         governorTokenDAO.initialize(

--- a/test/governor-token-dao.ts
+++ b/test/governor-token-dao.ts
@@ -109,17 +109,6 @@ describe("GovernorTokenDAO Tests", function () {
 
     await expect(
       governorTokenDAOInstance.initialize(
-        signers[0].address,
-        daoName,
-        "",
-        GovernorTransferToken.address
-      )
-    )
-      .to.revertedWithCustomError(governorTokenDAOInstance, "InvalidInput")
-      .withArgs("BaseDAO: url is empty");
-
-    await expect(
-      governorTokenDAOInstance.initialize(
         TestHelper.ZERO_ADDRESS,
         daoName,
         daoLogoUrl,

--- a/test/multi-sig-dao-test.ts
+++ b/test/multi-sig-dao-test.ts
@@ -407,23 +407,6 @@ describe("MultiSig tests", function () {
         .withArgs("BaseDAO: name is empty");
     });
 
-    it("Verify createDAO should be reverted when dao url is empty", async function () {
-      const { multiSigDAOFactoryInstance, doaSignersAddresses, daoAdminOne } =
-        await loadFixture(deployFixture);
-      await expect(
-        multiSigDAOFactoryInstance.createDAO(
-          daoAdminOne.address,
-          DAO_NAME,
-          "",
-          doaSignersAddresses,
-          doaSignersAddresses.length,
-          true
-        )
-      )
-        .to.revertedWithCustomError(multiSigDAOFactoryInstance, "InvalidInput")
-        .withArgs("BaseDAO: url is empty");
-    });
-
     it("Verify createDAO should add new dao into list when the dao is public", async function () {
       const { multiSigDAOFactoryInstance, doaSignersAddresses, daoAdminOne } =
         await loadFixture(deployFixture);

--- a/test/nft-dao-factory-test.ts
+++ b/test/nft-dao-factory-test.ts
@@ -120,25 +120,6 @@ describe("NFTDAOFactory contract tests", function () {
       .withArgs("DAOFactory: name is empty");
   });
 
-  it("Verify createDAO should be reverted when dao url is empty", async function () {
-    const { governorDAOFactoryInstance, daoAdminOne, token } =
-      await loadFixture(deployFixture);
-    await expect(
-      governorDAOFactoryInstance.createDAO(
-        daoAdminOne.address,
-        DAO_NAME,
-        "",
-        token.address,
-        BigNumber.from(500),
-        BigNumber.from(0),
-        BigNumber.from(100),
-        true
-      )
-    )
-      .to.revertedWithCustomError(governorDAOFactoryInstance, "InvalidInput")
-      .withArgs("DAOFactory: url is empty");
-  });
-
   it("Verify createDAO should be reverted when token address is zero", async function () {
     const { governorDAOFactoryInstance, daoAdminOne } = await loadFixture(
       deployFixture


### PR DESCRIPTION
🛠️ Fixes

-  A logo URL with a length greater than 0 is no longer required to create a DAO.

📝 Tech Notes

- UI validation portion of this bugfix: https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/pull/142
