### PR TITLE
Removes the need for NFTs to be transferred to NFTHolder contract

### DIFF
--- a/contracts/common/TokenOperations.sol
+++ b/contracts/common/TokenOperations.sol
@@ -29,6 +29,13 @@ contract TokenOperations {
         return IERC20(token).balanceOf(account);
     }
 
+    function _ownerOf(
+        address _token,
+        uint256 _tokenId
+    ) internal view returns (address) {
+        return IERC721(_token).ownerOf(_tokenId);
+    }
+
     function _associateToken(
         IHederaService _hederaService,
         address _account,

--- a/contracts/governance/NFTHolder.sol
+++ b/contracts/governance/NFTHolder.sol
@@ -22,13 +22,6 @@ contract NFTHolder is TokenHolder {
         uint256 tokenId = nftTokenForUsers[msg.sender];
         require(tokenId > 0, "NFTHolder: No amount for the Voter.");
         delete (nftTokenForUsers[msg.sender]);
-        _transferToken(
-            hederaService,
-            address(_token),
-            address(this),
-            msg.sender,
-            tokenId
-        );
         emit UpdatedAmount(msg.sender, nftTokenForUsers[msg.sender], UNLOCKED);
         return HederaResponseCodes.SUCCESS;
     }
@@ -38,14 +31,10 @@ contract NFTHolder is TokenHolder {
         if (nftTokenForUsers[user] > 0) {
             return;
         }
+        // verify if token exists and user is the owner
+        require(_ownerOf(_token, tokenId) == user, "NFTHolder: Not the owner of the token");
+
         nftTokenForUsers[user] = tokenId;
-        _transferToken(
-            hederaService,
-            address(_token),
-            address(user),
-            address(this),
-            tokenId
-        );
         emit UpdatedAmount(user, nftTokenForUsers[user], LOCKED);
     }
 

--- a/test/nft-holder-test.ts
+++ b/test/nft-holder-test.ts
@@ -102,14 +102,14 @@ describe("NFTHolder Tests", function () {
       .grabTokensFromUser(TestHelper.NFT_FOR_VOTING);
 
     const nftHolderBalance = await nftToken.balanceOf(nftHolder.address);
-    expect(nftHolderBalance).equal(1);
+    expect(nftHolderBalance).equal(0); // should not keet users nft
 
     expect(await nftToken.balanceOf(voterAccount.address)).equal(
-      TestHelper.NFT_IDS.length - 1,
+      TestHelper.NFT_IDS.length,
     );
 
     const votingTokenOwner = await nftToken.ownerOf(TestHelper.NFT_FOR_VOTING);
-    expect(votingTokenOwner).equal(nftHolder.address);
+    expect(votingTokenOwner).equal(voterAccount.address);
   });
 
   it("Verify add and remove active proposals", async function () {
@@ -164,9 +164,9 @@ describe("NFTHolder Tests", function () {
       .connect(voterAccount)
       .grabTokensFromUser(TestHelper.NFT_FOR_VOTING);
 
-    expect(await nftToken.balanceOf(nftHolder.address)).equal(1);
+    expect(await nftToken.balanceOf(nftHolder.address)).equal(0);
     expect(await nftToken.balanceOf(voterAccount.address)).equal(
-      TestHelper.NFT_IDS.length - 1,
+      TestHelper.NFT_IDS.length,
     );
 
     await nftHolder.connect(voterAccount).revertTokensForVoter(0);

--- a/test/single-governor-test.ts
+++ b/test/single-governor-test.ts
@@ -530,6 +530,13 @@ describe("Governor Tests", function () {
 
       await nftAsGodToken.setTotal(50);
       await nftTokenHolder.grabTokensFromUser(TestHelper.NFT_FOR_VOTING);
+
+      await nftAsGodToken.transferFrom(
+        await creator.getAddress(),
+        await signers[1].getAddress(),
+        TestHelper.NFT_FOR_VOTING,
+      );
+
       await nftTokenHolder.connect(signers[1]).grabTokensFromUser(1);
 
       const info = await createTextProposal(
@@ -953,6 +960,13 @@ describe("Governor Tests", function () {
         await nftTokenHolder
           .connect(creator)
           .grabTokensFromUser(TestHelper.NFT_FOR_VOTING);
+
+        await nftAsGodToken.transferFrom(
+          await creator.getAddress(),
+          await signers[1].getAddress(),
+          TestHelper.NFT_FOR_VOTING,
+        );
+
         await nftTokenHolder.connect(signers[1]).grabTokensFromUser(1);
 
         const info = await createTokenCreateProposal(
@@ -1216,6 +1230,13 @@ describe("Governor Tests", function () {
         await nftTokenHolder
           .connect(creator)
           .grabTokensFromUser(TestHelper.NFT_FOR_VOTING);
+
+        await nftAsGodToken.transferFrom(
+          await creator.getAddress(),
+          await signers[1].getAddress(),
+          TestHelper.NFT_FOR_VOTING,
+        );
+
         await nftTokenHolder.connect(signers[1]).grabTokensFromUser(1);
 
         const info = await createAssetsTransferProposal(
@@ -1250,6 +1271,13 @@ describe("Governor Tests", function () {
         } = await loadFixture(deployFixture);
         await nftAsGodToken.setTotal(50);
         await nftTokenHolder.grabTokensFromUser(TestHelper.NFT_FOR_VOTING);
+
+        await nftAsGodToken.transferFrom(
+          await creator.getAddress(),
+          await signers[1].getAddress(),
+          TestHelper.NFT_FOR_VOTING,
+        );
+
         await nftTokenHolder.connect(signers[1]).grabTokensFromUser(1);
 
         const info = await createAssetsTransferProposal(


### PR DESCRIPTION
**Description**:
This fix removes the need for NFTs to be transferred to NFTHolder contract.

**Checklist**

- [X] Tested (unit, integration, etc.)
